### PR TITLE
Use stride instead of width + misc clean up

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CCD - Camcorder Color Denoise
+﻿# CCD - Camcorder Color Denoise
 
 CCD is a simple chroma denoiser. It works by selectively averaging pixels in a 25x25 matrix below
 the Euclidean distance threshold in an RGB clip. After denoising, the clip should be converted back
@@ -49,3 +49,13 @@ Or you can use cmake - though I don't know how it works, and Scrad added it. Bla
 ## Dependencies
 
 Vapoursynth, obviously. That's it though :pogchamp:
+
+## Algorithm
+
+CCD is basically a bilateral filter, with the following characteristics:
+
+- Weight functions are simplified to a box instead of a Gaussian.
+
+- The kernel is subsampled, default is 8× in each direction, so 256× total.
+
+- Works on full pixels, not just on independent color channels as video filters often do.

--- a/src/ccd.cpp
+++ b/src/ccd.cpp
@@ -16,15 +16,15 @@
 // Convenient helper to declare unused function parameters
 template <typename... T> inline void unused (T &&...) noexcept {}
 
-static const double *init_multipliers() {
+static const float *init_multipliers() {
     const int n = 20; // number of multipliers
-    static double mutlipliers[n];
+    static float mutlipliers[n];
     for (int i=0; i<n; i++)
-        mutlipliers[i] = 1. / (i+1);
+        mutlipliers[i] = 1.f / float (i+1);
     return mutlipliers;
 }
 
-static const double *MULTIPLIERS = init_multipliers();
+static const float *MULTIPLIERS = init_multipliers();
 
 typedef struct ccdData {
     VSNode *node;

--- a/src/ccd.cpp
+++ b/src/ccd.cpp
@@ -9,6 +9,7 @@
  *  This project is licensed under the GPL v3 License.
  **/
 #include <memory>
+#include <cmath>
 
 #include <VapourSynth4.h>
 #include <VSHelper4.h>
@@ -162,7 +163,11 @@ static void VS_CC ccdCreate(const VSMap *in, VSMap *out, void *userData,
     d->node = vsapi->mapGetNode(in, "clip", 0, nullptr);
     d->threshold = static_cast<float>(vsapi->mapGetFloat(in, "threshold", 0, &err));
     if (err) d->threshold = 4;
-    d->threshold = d->threshold * d->threshold / 195075.0f; // the magic number - thanks DomBito
+    // The following calculation is equivalent to the orignal formula
+    // thr*thr/195075 but a bit more explicit.
+    // It is not known why the sqrt(3) factor has been introduced.
+    const auto scale = 255.f * sqrtf(3); // threshold unit is 1/scale-th of the data range [0 ; 1]
+    d->threshold = square(d->threshold / scale); // the magic number - thanks DomBito
 
     const VSVideoInfo *vi = vsapi->getVideoInfo(d->node);
 

--- a/src/ccd.cpp
+++ b/src/ccd.cpp
@@ -13,6 +13,9 @@
 #include <VapourSynth4.h>
 #include <VSHelper4.h>
 
+// Convenient helper to declare unused function parameters
+template <typename... T> inline void unused (T &&...) noexcept {}
+
 static const double *init_multipliers() {
     const int n = 20; // number of multipliers
     static double mutlipliers[n];
@@ -114,6 +117,7 @@ static const VSFrame *VS_CC ccdGetframe(int n, int activationReason,
                                         void **frameData,
                                         VSFrameContext *frameCtx,
                                         VSCore *core, const VSAPI *vsapi)  {
+    unused (frameData);
     auto *d = reinterpret_cast<ccdData *>(instanceData);
 
     if (activationReason == arInitial) {
@@ -141,6 +145,7 @@ static const VSFrame *VS_CC ccdGetframe(int n, int activationReason,
 }
 
 static void VS_CC ccdFree(void *instanceData, VSCore *core, const VSAPI *vsapi) {
+    unused (core);
     auto *d = reinterpret_cast<ccdData *>(instanceData);
     vsapi->freeNode(d->node);
     delete d;
@@ -148,6 +153,7 @@ static void VS_CC ccdFree(void *instanceData, VSCore *core, const VSAPI *vsapi) 
 
 static void VS_CC ccdCreate(const VSMap *in, VSMap *out, void *userData,
                             VSCore *core, const VSAPI *vsapi)  {
+    unused (userData);
     std::unique_ptr<ccdData> d(new ccdData());
     int err;
 

--- a/src/ccd.cpp
+++ b/src/ccd.cpp
@@ -16,6 +16,10 @@
 // Convenient helper to declare unused function parameters
 template <typename... T> inline void unused (T &&...) noexcept {}
 
+template <typename T> inline constexpr T square (T x) noexcept {
+    return x * x;
+}
+
 static const float *init_multipliers() {
     const int n = 20; // number of multipliers
     static float mutlipliers[n];
@@ -75,14 +79,12 @@ static void ccdRun(const VSFrame *src, VSFrame *dest, float threshold, const VSA
                     float diff_g = comp_g - g;
                     float diff_b = comp_b - b;
 
-#define SQUARE(x) ((x) * (x))
-                    if (threshold > (SQUARE(diff_r) + SQUARE(diff_g) + SQUARE(diff_b))) {
+                    if (threshold > (square(diff_r) + square(diff_g) + square(diff_b))) {
                         total_r += comp_r;
                         total_b += comp_b;
                         total_g += comp_g;
                         n++;
                     }
-#undef SQUARE
                 }
             }
 


### PR DESCRIPTION
Here is a proposal of a few changes and clean-up, in particular the use of stride instead of width to calculate pixel offsets in the frame.

I also slightly reworked the code to expose the Truth behind a few magical or mysterious constants, so code maintenance should be easier.